### PR TITLE
Add Xamarin iOS Unified API support

### DIFF
--- a/System.Data.SQLite.nuspec
+++ b/System.Data.SQLite.nuspec
@@ -7,15 +7,16 @@
     <owners>Logos Bible Software</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>An independent implementation of the core of ADO.NET.</description>
-    <copyright>Copyright 2014 Faithlife / Logos Bible Software</copyright>
+    <copyright>Copyright 2014-2015 Faithlife / Logos Bible Software</copyright>
     <dependencies>
-      <group targetFramework="portable-net45+win+wp8+MonoAndroid+MonoTouch">
+      <group targetFramework="portable-net45+win+wp8+MonoAndroid+MonoTouch+Xamarin.iOS10">
         <dependency id="Logos.PclContrib.Portable.Data" version="0.1.1" />
       </group>
       <group targetFramework="net45"></group>
       <group targetFramework="MonoMac"></group>
       <group targetFramework="MonoAndroid"></group>
       <group targetFramework="MonoTouch"></group>
+      <group targetFramework="Xamarin.iOS"></group>
     </dependencies>
   </metadata>
   <files>   
@@ -24,5 +25,6 @@
     <file src="src\System.Data.SQLite-Mac\bin\$configuration$\System.Data.SQLite.*" target="lib\MonoMac\" />
     <file src="src\System.Data.SQLite-MonoAndroid\bin\$configuration$\System.Data.SQLite.*" target="lib\MonoAndroid\" exclude="**\*.mdb" />
     <file src="src\System.Data.SQLite-MonoTouch\bin\$configuration$\System.Data.SQLite.*" target="lib\MonoTouch\" exclude="**\*.mdb" />
+    <file src="src\System.Data.SQLite-Xamarin.iOS\bin\$configuration$\System.Data.SQLite.*" target="lib\Xamarin.iOS\" exclude="**\*.mdb" />
   </files>
 </package>

--- a/System.Data.SQLite.sln
+++ b/System.Data.SQLite.sln
@@ -59,6 +59,7 @@ Global
 		Debug|Mixed Platforms = Debug|Mixed Platforms
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
+		Debug|Xamarin iOS = Debug|Xamarin iOS
 		Release|Any CPU = Release|Any CPU
 		Release|ARM = Release|ARM
 		Release|iPhone = Release|iPhone
@@ -66,6 +67,7 @@ Global
 		Release|Mixed Platforms = Release|Mixed Platforms
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
+		Release|Xamarin iOS = Release|Xamarin iOS
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{32486A50-1203-4AD4-90FC-685594C4929E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -308,6 +310,8 @@ Global
 		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Debug|x64.Build.0 = Debug|iPhoneSimulator
 		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Debug|x86.ActiveCfg = Debug|iPhoneSimulator
 		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Debug|x86.Build.0 = Debug|iPhoneSimulator
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Debug|Xamarin iOS.ActiveCfg = Debug|iPhoneSimulator
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Debug|Xamarin iOS.Build.0 = Debug|iPhoneSimulator
 		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Release|Any CPU.ActiveCfg = Release|iPhoneSimulator
 		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Release|ARM.ActiveCfg = Release|iPhoneSimulator
 		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Release|ARM.Build.0 = Release|iPhoneSimulator
@@ -324,6 +328,8 @@ Global
 		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Release|x64.Build.0 = Release|iPhoneSimulator
 		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Release|x86.ActiveCfg = Release|iPhoneSimulator
 		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Release|x86.Build.0 = Release|iPhoneSimulator
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Release|Xamarin iOS.ActiveCfg = Release|iPhoneSimulator
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Release|Xamarin iOS.Build.0 = Release|iPhoneSimulator
 		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Debug|ARM.ActiveCfg = Debug|Any CPU
 		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Debug|ARM.Build.0 = Debug|Any CPU
@@ -337,6 +343,8 @@ Global
 		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Debug|x64.Build.0 = Debug|Any CPU
 		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Debug|x86.Build.0 = Debug|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Debug|Xamarin iOS.ActiveCfg = Debug|Xamarin iOS
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Debug|Xamarin iOS.Build.0 = Debug|Xamarin iOS
 		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Release|ARM.ActiveCfg = Release|Any CPU
 		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Release|ARM.Build.0 = Release|Any CPU
@@ -350,6 +358,8 @@ Global
 		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Release|x64.Build.0 = Release|Any CPU
 		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Release|x86.ActiveCfg = Release|Any CPU
 		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Release|x86.Build.0 = Release|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Release|Xamarin iOS.ActiveCfg = Release|Xamarin iOS
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Release|Xamarin iOS.Build.0 = Release|Xamarin iOS
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/System.Data.SQLite.sln
+++ b/System.Data.SQLite.sln
@@ -32,6 +32,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Data.SQLite-Portable
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Data.SQLite.Tests-Store", "tests\System.Data.SQLite.Tests-Store\System.Data.SQLite.Tests-Store.csproj", "{74FCB15B-D0F0-4C0F-8B66-4F8CD72A7987}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Data.SQLite-Xamarin.iOS", "src\System.Data.SQLite-Xamarin.iOS\System.Data.SQLite-Xamarin.iOS.csproj", "{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Data.SQLite.Tests-Xamarin.iOS", "tests\System.Data.SQLite.Tests-Xamarin.iOS\System.Data.SQLite.Tests-Xamarin.iOS.csproj", "{6715BE21-C8FA-4690-90C8-1FDD4895E51C}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		tests\System.Data.SQLite.Tests\System.Data.SQLite.Tests.projitems*{20215817-078c-4f27-8d72-b016f07dd079}*SharedItemsImports = 4
@@ -288,6 +292,64 @@ Global
 		{74FCB15B-D0F0-4C0F-8B66-4F8CD72A7987}.Release|x86.ActiveCfg = Release|x86
 		{74FCB15B-D0F0-4C0F-8B66-4F8CD72A7987}.Release|x86.Build.0 = Release|x86
 		{74FCB15B-D0F0-4C0F-8B66-4F8CD72A7987}.Release|x86.Deploy.0 = Release|x86
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Debug|Any CPU.ActiveCfg = Debug|iPhone
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Debug|ARM.ActiveCfg = Debug|iPhone
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Debug|ARM.Build.0 = Debug|iPhoneSimulator
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Debug|iPhone.ActiveCfg = Debug|iPhone
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Debug|iPhone.Build.0 = Debug|iPhone
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Debug|iPhone.Deploy.0 = Debug|iPhone
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Debug|iPhoneSimulator.Deploy.0 = Debug|iPhoneSimulator
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Debug|Mixed Platforms.ActiveCfg = Debug|iPhoneSimulator
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Debug|Mixed Platforms.Build.0 = Debug|iPhone
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Debug|Mixed Platforms.Deploy.0 = Debug|iPhone
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Debug|x64.ActiveCfg = Debug|iPhoneSimulator
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Debug|x64.Build.0 = Debug|iPhoneSimulator
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Debug|x86.ActiveCfg = Debug|iPhoneSimulator
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Debug|x86.Build.0 = Debug|iPhoneSimulator
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Release|Any CPU.ActiveCfg = Release|iPhoneSimulator
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Release|ARM.ActiveCfg = Release|iPhoneSimulator
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Release|ARM.Build.0 = Release|iPhoneSimulator
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Release|iPhone.ActiveCfg = Release|iPhone
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Release|iPhone.Build.0 = Release|iPhone
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Release|iPhone.Deploy.0 = Release|iPhone
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Release|iPhoneSimulator.Deploy.0 = Release|iPhoneSimulator
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Release|Mixed Platforms.ActiveCfg = Release|iPhoneSimulator
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Release|Mixed Platforms.Build.0 = Release|iPhoneSimulator
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Release|Mixed Platforms.Deploy.0 = Release|iPhone
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Release|x64.ActiveCfg = Release|iPhoneSimulator
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Release|x64.Build.0 = Release|iPhoneSimulator
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Release|x86.ActiveCfg = Release|iPhoneSimulator
+		{6715BE21-C8FA-4690-90C8-1FDD4895E51C}.Release|x86.Build.0 = Release|iPhoneSimulator
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Debug|ARM.Build.0 = Debug|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Debug|x64.Build.0 = Debug|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Debug|x86.Build.0 = Debug|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Release|ARM.ActiveCfg = Release|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Release|ARM.Build.0 = Release|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Release|iPhone.Build.0 = Release|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Release|x64.ActiveCfg = Release|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Release|x64.Build.0 = Release|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Release|x86.ActiveCfg = Release|Any CPU
+		{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/build.ps1
+++ b/build.ps1
@@ -7,6 +7,7 @@ Task Default -depends NuGetPack
 Task Build {
   Exec { nuget restore }
   Exec { msbuild /m:4 /p:Configuration=$configuration /p:Platform="Any CPU" /p:VisualStudioVersion=12.0 System.Data.SQLite.sln }
+  Exec { msbuild /m:4 /p:Configuration=$configuration /p:Platform="Xamarin iOS" /p:VisualStudioVersion=12.0 System.Data.SQLite.sln }
 }
 
 Task Tests -depends Build {

--- a/src/System.Data.SQLite-Xamarin.iOS/System.Data.SQLite-Xamarin.iOS.csproj
+++ b/src/System.Data.SQLite-Xamarin.iOS/System.Data.SQLite-Xamarin.iOS.csproj
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>System.Data.SQLite</RootNamespace>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <AssemblyName>System.Data.SQLite</AssemblyName>
+    <TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;XAMARIN_IOS;MONO</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <DefineConstants>XAMARIN_IOS;MONO</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Xamarin.iOS" />
+  </ItemGroup>
+  <Import Project="..\System.Data.SQLite\System.Data.SQLite.projitems" Label="Shared" Condition="Exists('..\System.Data.SQLite\System.Data.SQLite.projitems')" />
+  <Import Project="..\..\Xamarin.NotInstalled.targets" Condition="!Exists('$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets')" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+  <ItemGroup>
+    <Compile Include="..\..\SolutionVersion.cs">
+      <Link>Properties\SolutionVersion.cs</Link>
+    </Compile>
+  </ItemGroup>
+</Project>

--- a/src/System.Data.SQLite-Xamarin.iOS/System.Data.SQLite-Xamarin.iOS.csproj
+++ b/src/System.Data.SQLite-Xamarin.iOS/System.Data.SQLite-Xamarin.iOS.csproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">Xamarin iOS</Platform>
     <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectGuid>{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -12,7 +12,7 @@
     <TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|Xamarin iOS' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -23,7 +23,7 @@
     <ConsolePause>false</ConsolePause>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|Xamarin iOS' ">
     <Optimize>true</Optimize>
     <OutputPath>bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>

--- a/src/System.Data.SQLite/SQLiteDataReader.cs
+++ b/src/System.Data.SQLite/SQLiteDataReader.cs
@@ -509,6 +509,8 @@ namespace System.Data.SQLite
 
 #if MONOTOUCH
 		[MonoTouch.MonoPInvokeCallback(typeof(SQLiteProgressCallback))]
+#elif XAMARIN_IOS
+		[ObjCRuntime.MonoPInvokeCallback(typeof(SQLiteProgressCallback))]
 #endif
 		private static int IsCanceled(IntPtr userData)
 		{

--- a/src/System.Data.SQLite/SQLiteLog.cs
+++ b/src/System.Data.SQLite/SQLiteLog.cs
@@ -34,6 +34,8 @@
 
 #if MONOTOUCH
 		[MonoTouch.MonoPInvokeCallback(typeof(SQLiteLogCallback))]
+#elif XAMARIN_IOS
+		[ObjCRuntime.MonoPInvokeCallback(typeof(SQLiteLogCallback))]
 #endif
 		static void LogCallback(IntPtr pUserData, int errorCode, IntPtr pMessage)
 		{

--- a/tests/System.Data.SQLite.Tests-Xamarin.iOS/Entitlements.plist
+++ b/tests/System.Data.SQLite.Tests-Xamarin.iOS/Entitlements.plist
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/tests/System.Data.SQLite.Tests-Xamarin.iOS/Info.plist
+++ b/tests/System.Data.SQLite.Tests-Xamarin.iOS/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>System.Data.SQLite.Tests-Xamarin.iOS</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.logos.System.Data.SQLite.TestsXamariniOS</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>MinimumOSVersion</key>
+	<string>7.0</string>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/tests/System.Data.SQLite.Tests-Xamarin.iOS/Main.cs
+++ b/tests/System.Data.SQLite.Tests-Xamarin.iOS/Main.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Foundation;
+using UIKit;
+
+namespace System.Data.SQLite.Tests
+{
+	public class Application
+	{
+		// This is the main entry point of the application.
+		static void Main(string[] args)
+		{
+			// if you want to use a different Application Delegate class from "UnitTestAppDelegate"
+			// you can specify it here.
+			UIApplication.Main(args, null, "UnitTestAppDelegate");
+		}
+	}
+}

--- a/tests/System.Data.SQLite.Tests-Xamarin.iOS/System.Data.SQLite.Tests-Xamarin.iOS.csproj
+++ b/tests/System.Data.SQLite.Tests-Xamarin.iOS/System.Data.SQLite.Tests-Xamarin.iOS.csproj
@@ -1,0 +1,129 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{6715BE21-C8FA-4690-90C8-1FDD4895E51C</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>System.Data.SQLite.Tests</RootNamespace>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <AssemblyName>SystemDataSQLiteTestsMonoTouch</AssemblyName>
+    <TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
+    <DefineConstants>DEBUG;__IOS__;__MOBILE__;XAMARIN_IOS;MONO</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <MtouchLink>None</MtouchLink>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchDebug>true</MtouchDebug>
+    <MtouchI18n>
+    </MtouchI18n>
+    <MtouchArch>ARMv7</MtouchArch>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
+    <DefineConstants>__IOS__;__MOBILE__;XAMARIN_IOS;MONO</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <MtouchLink>None</MtouchLink>
+    <ConsolePause>false</ConsolePause>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhone\Debug</OutputPath>
+    <DefineConstants>DEBUG;__IOS__;__MOBILE__;XAMARIN_IOS;MONO</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchDebug>True</MtouchDebug>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <IpaPackageName>
+    </IpaPackageName>
+    <MtouchI18n>
+    </MtouchI18n>
+    <MtouchArch>ARMv7</MtouchArch>
+    <MtouchExtraArgs>
+    </MtouchExtraArgs>
+    <MtouchOptimizePNGs>True</MtouchOptimizePNGs>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Release</OutputPath>
+    <DefineConstants>__IOS__;__MOBILE__;XAMARIN_IOS;MONO</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <ConsolePause>false</ConsolePause>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Ad-Hoc</OutputPath>
+    <DefineConstants>__IOS__;__MOBILE__;XAMARIN_IOS;MONO</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <BuildIpa>true</BuildIpa>
+    <CodesignProvision>Automatic:AdHoc</CodesignProvision>
+    <CodesignKey>iPhone Distribution</CodesignKey>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|iPhone' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\AppStore</OutputPath>
+    <DefineConstants>__IOS__;__MOBILE__;XAMARIN_IOS;MONO</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <CodesignProvision>Automatic:AppStore</CodesignProvision>
+    <CodesignKey>iPhone Distribution</CodesignKey>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="MonoTouch.NUnitLite" />
+    <Reference Include="System.Data" />
+    <Reference Include="Xamarin.iOS" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Info.plist" />
+    <None Include="Entitlements.plist" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Main.cs" />
+    <Compile Include="UnitTestAppDelegate.cs" />
+    <Compile Include="..\..\SolutionVersion.cs">
+      <Link>Properties\SolutionVersion.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <Import Project="..\System.Data.SQLite.Tests\System.Data.SQLite.Tests.projitems" Label="Shared" Condition="Exists('..\System.Data.SQLite.Tests\System.Data.SQLite.Tests.projitems')" />
+  <Import Project="..\..\Xamarin.NotInstalled.targets" Condition="!Exists('$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets')" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Data.SQLite-Xamarin.iOS\System.Data.SQLite-Xamarin.iOS.csproj">
+      <Project>{D3CC87AE-9C4B-4A80-97CE-73B7F03391CD}</Project>
+      <Name>System.Data.SQLite-Xamarin.iOS</Name>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/tests/System.Data.SQLite.Tests-Xamarin.iOS/UnitTestAppDelegate.cs
+++ b/tests/System.Data.SQLite.Tests-Xamarin.iOS/UnitTestAppDelegate.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Foundation;
+using UIKit;
+using MonoTouch.NUnit.UI;
+
+namespace System.Data.SQLite.Tests
+{
+	// The UIApplicationDelegate for the application. This class is responsible for launching the
+	// User Interface of the application, as well as listening (and optionally responding) to
+	// application events from iOS.
+	[Register("UnitTestAppDelegate")]
+	public partial class UnitTestAppDelegate : UIApplicationDelegate
+	{
+		// class-level declarations
+		UIWindow window;
+		TouchRunner runner;
+
+		//
+		// This method is invoked when the application has loaded and is ready to run. In this
+		// method you should instantiate the window, load the UI into it and then make the window
+		// visible.
+		//
+		// You have 17 seconds to return from this method, or iOS will terminate your application.
+		//
+		public override bool FinishedLaunching(UIApplication app, NSDictionary options)
+		{
+			// create a new window instance based on the screen size
+			window = new UIWindow(UIScreen.MainScreen.Bounds);
+			runner = new TouchRunner(window);
+
+			// register every tests included in the main application/assembly
+			runner.Add(System.Reflection.Assembly.GetExecutingAssembly());
+
+			window.RootViewController = new UINavigationController(runner.GetViewController());
+			
+			// make the window visible
+			window.MakeKeyAndVisible();
+			
+			return true;
+		}
+	}
+}
+


### PR DESCRIPTION
I've added Xamarin.iOS projects that use the new [Xamarin Unified API](http://developer.xamarin.com/guides/cross-platform/macios/unified/) rather than MonoTouch.

I've tried to update the .nuspec file but I'm not sure how to test it short of running it on Jenkins/AppVeyor (which may require an update to the Xamarin tooling to include the new Unified APIs)