### PR TITLE
Allow path to git.exe to be overridden by -properties

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,5 +1,6 @@
 properties {
   $configuration = "Release"
+  $gitPath = "C:\Program Files (x86)\Git\bin\git.exe"
 }
 
 Task Default -depends NuGetPack
@@ -15,7 +16,7 @@ Task Tests -depends Build {
 }
 
 Task SourceIndex -depends Tests {
-  $headSha = & "C:\Program Files (x86)\Git\bin\git.exe" rev-parse HEAD
+  $headSha = & $gitPath rev-parse HEAD
   foreach ($project in @("System.Data.SQLite-Mac", "System.Data.SQLite-MonoAndroid", "System.Data.SQLite-MonoTouch", "System.Data.SQLite-Net45", "System.Data.SQLite-Portable")) {
     Exec { tools\SourceIndex\github-sourceindexer.ps1 -symbolsFolder src\$project\bin\$configuration -userId LogosBible -repository System.Data.SQLite -branch $headSha -sourcesRoot ${pwd} -dbgToolsPath "C:\Program Files (x86)\Windows Kits\8.1\Debuggers\x86" -gitHubUrl "https://raw.github.com" -serverIsRaw -ignoreUnknown -verbose }
   }


### PR DESCRIPTION
e.g. build.ps -properties @{"gitPath" = "C:\cygwin\bin\git.exe"}