### PR TITLE
Promote $version to script level variable.

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -6,6 +6,8 @@ properties {
   $nugetPackageSource = $null
 }
 
+$version = $null
+
 Task Default -depends NuGetPack, NuGetPublish
 
 Task Clean {
@@ -36,10 +38,10 @@ Task SourceIndex -depends Tests {
 
 Task NuGetPack -depends SourceIndex {
   mkdir $outputDir -force
-  $version = [System.Diagnostics.FileVersionInfo]::GetVersionInfo("src\System.Data.SQLite-Net45\bin\$configuration\System.Data.SQLite.dll").FileVersion
+  $script:version = [System.Diagnostics.FileVersionInfo]::GetVersionInfo("src\System.Data.SQLite-Net45\bin\$configuration\System.Data.SQLite.dll").FileVersion
   Exec { tools\NuGet\NuGet pack System.Data.SQLite.nuspec -Version $version -Prop Configuration=$configuration -Symbols -OutputDirectory $outputDir }
 }
 
 Task NuGetPublish -depends NuGetPack -precondition { return $apiKey -and $nugetPackageSource } {
-  Exec { tools\NuGet\NuGet push $outputDir\Logos.System.Data.SQLite.$version.nupkg -ApiKey $apiKey -Source $nugetPackageSource }
+  Exec { tools\NuGet\NuGet push $outputDir\Logos.System.Data.SQLite.$script:version.nupkg -ApiKey $apiKey -Source $nugetPackageSource }
 }


### PR DESCRIPTION
This allows the value to be correctly reused in NugetPublish.